### PR TITLE
Support for ECS Service Discovery

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,7 @@ dependencies {
             "software.amazon.awssdk:lambda:$awsSdkVersion",
             "software.amazon.awssdk:dynamodb:$awsSdkVersion",
             "software.amazon.awssdk:s3:$awsSdkVersion",
+            "software.amazon.awssdk:ecs:$awsSdkVersion",
             "software.amazon.awssdk:resourcegroupstaggingapi:$awsSdkVersion",
     )
 

--- a/src/main/java/ai/asserts/aws/AWSClientProvider.java
+++ b/src/main/java/ai/asserts/aws/AWSClientProvider.java
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Component;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.cloudwatch.CloudWatchClient;
 import software.amazon.awssdk.services.cloudwatchlogs.CloudWatchLogsClient;
+import software.amazon.awssdk.services.ecs.EcsClient;
 import software.amazon.awssdk.services.lambda.LambdaClient;
 import software.amazon.awssdk.services.resourcegroupstaggingapi.ResourceGroupsTaggingApiClient;
 
@@ -27,5 +28,9 @@ public class AWSClientProvider {
 
     public ResourceGroupsTaggingApiClient getResourceTagClient(String region) {
         return ResourceGroupsTaggingApiClient.builder().region(Region.of(region)).build();
+    }
+
+    public EcsClient getECSClient(String region) {
+        return EcsClient.builder().region(Region.of(region)).build();
     }
 }

--- a/src/main/java/ai/asserts/aws/MetricTaskManager.java
+++ b/src/main/java/ai/asserts/aws/MetricTaskManager.java
@@ -4,6 +4,7 @@ package ai.asserts.aws;
 import ai.asserts.aws.cloudwatch.config.MetricConfig;
 import ai.asserts.aws.cloudwatch.config.ScrapeConfig;
 import ai.asserts.aws.cloudwatch.config.ScrapeConfigProvider;
+import ai.asserts.aws.exporter.ECSServiceDiscoveryExporter;
 import ai.asserts.aws.exporter.LambdaLogMetricScrapeTask;
 import ai.asserts.aws.exporter.MetricScrapeTask;
 import com.google.common.annotations.VisibleForTesting;
@@ -32,6 +33,7 @@ public class MetricTaskManager implements InitializingBean {
     private final CollectorRegistry collectorRegistry;
     private final AutowireCapableBeanFactory beanFactory;
     private final ScrapeConfigProvider scrapeConfigProvider;
+    private final ECSServiceDiscoveryExporter ecsServiceDiscoveryExporter;
     private final TaskThreadPool taskThreadPool;
 
     /**
@@ -88,6 +90,8 @@ public class MetricTaskManager implements InitializingBean {
                     executorService.submit(task::update);
                     sleep(2000L);
                 });
+
+        executorService.submit(ecsServiceDiscoveryExporter);
     }
 
     private void sleep(long time) {

--- a/src/main/java/ai/asserts/aws/ObjectMapperFactory.java
+++ b/src/main/java/ai/asserts/aws/ObjectMapperFactory.java
@@ -1,0 +1,21 @@
+/*
+ *  Copyright © 2020.
+ *  Asserts, Inc. - All Rights Reserved
+ */
+package ai.asserts.aws;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import com.fasterxml.jackson.dataformat.yaml.YAMLGenerator;
+import lombok.Getter;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ObjectMapperFactory {
+    @Getter
+    private final ObjectMapper objectMapper = new ObjectMapper(new YAMLFactory()
+            .disable(YAMLGenerator.Feature.WRITE_DOC_START_MARKER)
+            .enable(YAMLGenerator.Feature.MINIMIZE_QUOTES))
+            .setSerializationInclusion(JsonInclude.Include.NON_NULL);
+}

--- a/src/main/java/ai/asserts/aws/cloudwatch/config/ECSTaskDefScrapeConfig.java
+++ b/src/main/java/ai/asserts/aws/cloudwatch/config/ECSTaskDefScrapeConfig.java
@@ -1,0 +1,48 @@
+/*
+ *  Copyright © 2020.
+ *  Asserts, Inc. - All Rights Reserved
+ */
+package ai.asserts.aws.cloudwatch.config;
+
+import ai.asserts.aws.resource.Resource;
+import io.micrometer.core.instrument.util.StringUtils;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.With;
+
+import static ai.asserts.aws.resource.ResourceType.ECSTaskDef;
+
+@EqualsAndHashCode
+@Getter
+@SuppressWarnings("FieldMayBeFinal")
+@NoArgsConstructor
+@With
+@AllArgsConstructor
+public class ECSTaskDefScrapeConfig {
+    private String taskDefinitionName;
+    private String taskDefinitionVersion;
+    private String containerDefinitionName;
+    private Integer containerPort;
+    private String metricPath;
+
+    @EqualsAndHashCode
+    @Getter
+    @Builder
+    public static class ScrapeTarget {
+        private Integer containerPort;
+        private String metricPath;
+    }
+
+    public boolean validate() {
+        return StringUtils.isNotEmpty(taskDefinitionName) && (containerPort != null || metricPath != null);
+    }
+
+    public boolean isApplicable(Resource taskDefResource) {
+        return taskDefResource.getType().equals(ECSTaskDef) &&
+                taskDefResource.getName().equals(taskDefinitionName) &&
+                (taskDefinitionVersion == null || taskDefResource.getVersion().equals(taskDefinitionVersion));
+    }
+}

--- a/src/main/java/ai/asserts/aws/cloudwatch/config/NamespaceConfig.java
+++ b/src/main/java/ai/asserts/aws/cloudwatch/config/NamespaceConfig.java
@@ -1,6 +1,7 @@
 
 package ai.asserts.aws.cloudwatch.config;
 
+import ai.asserts.aws.resource.Resource;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.micrometer.core.instrument.util.StringUtils;
 import lombok.AllArgsConstructor;
@@ -15,6 +16,7 @@ import org.springframework.util.CollectionUtils;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.regex.Pattern;
@@ -41,6 +43,7 @@ public class NamespaceConfig {
     private Map<String, Set<String>> tagFilters;
     private List<MetricConfig> metrics;
     private List<LogScrapeConfig> logs;
+    private List<ECSTaskDefScrapeConfig> ecsTaskDefScrapeConfigs;
 
     public void validate(int index) {
         List<String> errors = new ArrayList<>();

--- a/src/main/java/ai/asserts/aws/cloudwatch/config/ScrapeConfigProvider.java
+++ b/src/main/java/ai/asserts/aws/cloudwatch/config/ScrapeConfigProvider.java
@@ -1,12 +1,9 @@
 
 package ai.asserts.aws.cloudwatch.config;
 
+import ai.asserts.aws.ObjectMapperFactory;
 import ai.asserts.aws.cloudwatch.model.CWNamespace;
-import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
-import com.fasterxml.jackson.dataformat.yaml.YAMLGenerator;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Suppliers;
 import lombok.extern.slf4j.Slf4j;
@@ -15,6 +12,7 @@ import org.springframework.core.io.FileSystemResourceLoader;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.ResourceLoader;
 import org.springframework.stereotype.Component;
+import org.springframework.util.CollectionUtils;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -28,18 +26,16 @@ import java.util.stream.Stream;
 @Component
 @Slf4j
 public class ScrapeConfigProvider {
-
-    private final ObjectMapper objectMapper = new ObjectMapper(new YAMLFactory()
-            .disable(YAMLGenerator.Feature.WRITE_DOC_START_MARKER)
-            .enable(YAMLGenerator.Feature.MINIMIZE_QUOTES))
-            .setSerializationInclusion(JsonInclude.Include.NON_NULL);
+    private final ObjectMapperFactory objectMapperFactory;
     private final ResourceLoader resourceLoader = new FileSystemResourceLoader();
     private final String scrapeConfigFile;
     private final Supplier<ScrapeConfig> configCache;
     private final Map<String, CWNamespace> byNamespace = new TreeMap<>();
     private final Map<String, CWNamespace> byServiceName = new TreeMap<>();
 
-    public ScrapeConfigProvider(@Value("${scrape.config.file:cloudwatch_scrape_config.yml}") String scrapeConfigFile) {
+    public ScrapeConfigProvider(ObjectMapperFactory objectMapperFactory,
+                                @Value("${scrape.config.file:cloudwatch_scrape_config.yml}") String scrapeConfigFile) {
+        this.objectMapperFactory = objectMapperFactory;
         this.scrapeConfigFile = scrapeConfigFile;
         configCache = Suppliers.memoize(this::load);
         Stream.of(CWNamespace.values()).forEach(namespace -> {
@@ -57,8 +53,9 @@ public class ScrapeConfigProvider {
         try {
             Resource resource = resourceLoader.getResource(scrapeConfigFile);
             url = resource.getURL();
-            ScrapeConfig scrapeConfig = objectMapper.readValue(url, new TypeReference<ScrapeConfig>() {
-            });
+            ScrapeConfig scrapeConfig = objectMapperFactory.getObjectMapper()
+                    .readValue(url, new TypeReference<ScrapeConfig>() {
+                    });
 
             validateConfig(scrapeConfig);
             log.info("Loaded cloudwatch scrape configuration from url={}", url);
@@ -71,10 +68,16 @@ public class ScrapeConfigProvider {
 
     @VisibleForTesting
     public void validateConfig(ScrapeConfig scrapeConfig) {
-        for (int i = 0; i < scrapeConfig.getNamespaces().size(); i++) {
-            NamespaceConfig namespaceConfig = scrapeConfig.getNamespaces().get(i);
-            namespaceConfig.setScrapeConfig(scrapeConfig);
-            namespaceConfig.validate(i);
+        if (!CollectionUtils.isEmpty(scrapeConfig.getNamespaces())) {
+            for (int i = 0; i < scrapeConfig.getNamespaces().size(); i++) {
+                NamespaceConfig namespaceConfig = scrapeConfig.getNamespaces().get(i);
+                namespaceConfig.setScrapeConfig(scrapeConfig);
+                namespaceConfig.validate(i);
+            }
+        }
+
+        if (!CollectionUtils.isEmpty(scrapeConfig.getEcsTaskScrapeConfigs())) {
+            scrapeConfig.getEcsTaskScrapeConfigs().forEach(ECSTaskDefScrapeConfig::validate);
         }
     }
 

--- a/src/main/java/ai/asserts/aws/cloudwatch/model/CWNamespace.java
+++ b/src/main/java/ai/asserts/aws/cloudwatch/model/CWNamespace.java
@@ -78,4 +78,8 @@ public enum CWNamespace {
                 normalizedNamespace = namespace;
         }
     }
+
+    public boolean isThisNamespace(String name) {
+        return name().equals(name) || namespace.equals(name);
+    }
 }

--- a/src/main/java/ai/asserts/aws/exporter/ECSServiceDiscoveryExporter.java
+++ b/src/main/java/ai/asserts/aws/exporter/ECSServiceDiscoveryExporter.java
@@ -1,0 +1,196 @@
+/*
+ *  Copyright © 2020.
+ *  Asserts, Inc. - All Rights Reserved
+ */
+package ai.asserts.aws.exporter;
+
+import ai.asserts.aws.AWSClientProvider;
+import ai.asserts.aws.ObjectMapperFactory;
+import ai.asserts.aws.cloudwatch.config.ScrapeConfig;
+import ai.asserts.aws.cloudwatch.config.ScrapeConfigProvider;
+import ai.asserts.aws.cloudwatch.model.CWNamespace;
+import ai.asserts.aws.resource.Resource;
+import ai.asserts.aws.resource.ResourceMapper;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableSortedMap;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import software.amazon.awssdk.services.ecs.EcsClient;
+import software.amazon.awssdk.services.ecs.model.DescribeTasksRequest;
+import software.amazon.awssdk.services.ecs.model.DescribeTasksResponse;
+import software.amazon.awssdk.services.ecs.model.ListClustersResponse;
+import software.amazon.awssdk.services.ecs.model.ListServicesRequest;
+import software.amazon.awssdk.services.ecs.model.ListServicesResponse;
+import software.amazon.awssdk.services.ecs.model.ListTasksRequest;
+import software.amazon.awssdk.services.ecs.model.ListTasksResponse;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.stream.Collectors;
+
+import static ai.asserts.aws.MetricNameUtil.SCRAPE_ERROR_COUNT_METRIC;
+import static ai.asserts.aws.MetricNameUtil.SCRAPE_LATENCY_METRIC;
+import static ai.asserts.aws.MetricNameUtil.SCRAPE_NAMESPACE_LABEL;
+import static ai.asserts.aws.MetricNameUtil.SCRAPE_OPERATION_LABEL;
+
+/**
+ * Exports the Service Discovery file with the list of task instances running in ECS across clusters and services
+ * within the clusters
+ */
+@AllArgsConstructor
+@Slf4j
+@Component
+public class ECSServiceDiscoveryExporter implements Runnable {
+    private final ScrapeConfigProvider scrapeConfigProvider;
+    private final AWSClientProvider awsClientProvider;
+    private final ResourceMapper resourceMapper;
+    private final ECSTaskUtil ecsTaskUtil;
+    private final BasicMetricCollector metricCollector;
+    private final ObjectMapperFactory objectMapperFactory;
+
+    @Override
+    public void run() {
+        ScrapeConfig scrapeConfig = scrapeConfigProvider.getScrapeConfig();
+        if (scrapeConfig.isECSMonitoringOn()) {
+            List<StaticConfig> latestTargets = new ArrayList<>();
+            Set<String> regions = scrapeConfig.getRegions();
+            ImmutableSortedMap<String, String> TELEMETRY_LABELS = ImmutableSortedMap.of(
+                    SCRAPE_OPERATION_LABEL, "listClusters",
+                    SCRAPE_NAMESPACE_LABEL, CWNamespace.ecs_svc.getNormalizedNamespace());
+            for (String region : regions) {
+                try (EcsClient ecsClient = awsClientProvider.getECSClient(region)) {
+                    // List clusters just returns the cluster ARN. There is no need to paginate
+                    long tick = System.currentTimeMillis();
+                    ListClustersResponse listClustersResponse = ecsClient.listClusters();
+                    tick = System.currentTimeMillis() - tick;
+                    metricCollector.recordLatency(SCRAPE_LATENCY_METRIC, TELEMETRY_LABELS, tick);
+                    if (listClustersResponse.hasClusterArns()) {
+                        listClustersResponse.clusterArns()
+                                .stream()
+                                .map(resourceMapper::map)
+                                .filter(Optional::isPresent)
+                                .map(Optional::get)
+                                .forEach(cluster ->
+                                        latestTargets.addAll(buildTargetsInCluster(scrapeConfig, ecsClient, cluster)));
+                    }
+                } catch (Exception e) {
+                    metricCollector.recordCounterValue(SCRAPE_ERROR_COUNT_METRIC, TELEMETRY_LABELS, 1);
+                    log.error("Failed to get list of ECS Clusters", e);
+                }
+            }
+            try {
+                objectMapperFactory.getObjectMapper().writerWithDefaultPrettyPrinter()
+                        .writeValue(new File("ecs_task_scrape_targets.yml"), latestTargets);
+            } catch (IOException e) {
+                metricCollector.recordCounterValue(SCRAPE_ERROR_COUNT_METRIC, ImmutableSortedMap.of(
+                        SCRAPE_OPERATION_LABEL, "ecs_sd_file_generation"), 1);
+                log.error("Failed to get list of ECS Clusters", e);
+            }
+        }
+    }
+
+    @VisibleForTesting
+    List<StaticConfig> buildTargetsInCluster(ScrapeConfig scrapeConfig, EcsClient ecsClient, Resource cluster) {
+        List<StaticConfig> targets = new ArrayList<>();
+        // List services just returns the service ARN. There is no need to paginate
+        ListServicesRequest serviceReq = ListServicesRequest.builder()
+                .cluster(cluster.getName())
+                .build();
+        ListServicesResponse serviceResp = ecsClient.listServices(serviceReq);
+        if (serviceResp.hasServiceArns()) {
+            serviceResp.serviceArns()
+                    .stream()
+                    .map(resourceMapper::map)
+                    .filter(Optional::isPresent)
+                    .map(Optional::get)
+                    .forEach(service ->
+                            targets.addAll(buildTargetsInService(scrapeConfig, ecsClient, cluster, service)));
+        }
+        return targets;
+    }
+
+    @VisibleForTesting
+    List<StaticConfig> buildTargetsInService(ScrapeConfig scrapeConfig, EcsClient ecsClient, Resource cluster,
+                                             Resource service) {
+        List<StaticConfig> scrapeTargets = new ArrayList<>();
+        Set<String> taskIds = new TreeSet<>();
+        String nextToken = null;
+        do {
+            long time = System.currentTimeMillis();
+            ListTasksResponse tasksResp = ecsClient.listTasks(ListTasksRequest.builder()
+                    .cluster(cluster.getName())
+                    .serviceName(service.getName())
+                    .nextToken(nextToken)
+                    .build());
+            time = System.currentTimeMillis() - time;
+            metricCollector.recordLatency(SCRAPE_LATENCY_METRIC, ImmutableSortedMap.of(), time);
+            nextToken = tasksResp.nextToken();
+            if (tasksResp.hasTaskArns()) {
+                for (String taskArn : tasksResp.taskArns()) {
+                    taskIds.add(taskArn);
+                    if (taskIds.size() == 100) {
+                        scrapeTargets.addAll(buildTaskTargets(scrapeConfig, ecsClient, cluster, service, taskIds));
+                        taskIds = new TreeSet<>();
+                    }
+                }
+            }
+        } while (nextToken != null);
+
+        // Either the first batch was lass than 100 or this is the last batch
+        if (taskIds.size() > 0) {
+            scrapeTargets.addAll(buildTaskTargets(scrapeConfig, ecsClient, cluster, service, taskIds));
+        }
+        return scrapeTargets;
+    }
+
+    @VisibleForTesting
+    List<StaticConfig> buildTaskTargets(ScrapeConfig scrapeConfig, EcsClient ecsClient, Resource cluster,
+                                        Resource service, Set<String> taskARNs) {
+        List<StaticConfig> configs = new ArrayList<>();
+        DescribeTasksResponse taskResponse = ecsClient.describeTasks(DescribeTasksRequest.builder()
+                .cluster(cluster.getName())
+                .tasks(taskARNs)
+                .build());
+        if (taskResponse.hasTasks()) {
+            configs.addAll(taskResponse.tasks().stream()
+                    .filter(ecsTaskUtil::hasAllInfo)
+                    .map(task -> ecsTaskUtil.buildScrapeTarget(scrapeConfig, ecsClient, cluster, service, task))
+                    .filter(Optional::isPresent)
+                    .map(Optional::get)
+                    .collect(Collectors.toList()));
+        }
+        return configs;
+    }
+
+    @Builder
+    @Getter
+    public static class StaticConfig {
+        private final Set<String> targets;
+        private final Labels labels;
+    }
+
+    @Getter
+    @Builder
+    public static class Labels {
+        @JsonProperty("__metrics_path__")
+        private final String metricsPath;
+        private final String job;
+        @JsonProperty("ecs_cluster")
+        private final String cluster;
+        @JsonProperty("ecs_taskdef_name")
+        private final String taskDefName;
+        @JsonProperty("ecs_taskdef_version")
+        private final String taskDefVersion;
+        @JsonProperty("ecs_task_id")
+        private final String taskId;
+    }
+}

--- a/src/main/java/ai/asserts/aws/exporter/ECSTaskUtil.java
+++ b/src/main/java/ai/asserts/aws/exporter/ECSTaskUtil.java
@@ -1,0 +1,148 @@
+/*
+ *  Copyright © 2020.
+ *  Asserts, Inc. - All Rights Reserved
+ */
+package ai.asserts.aws.exporter;
+
+import ai.asserts.aws.cloudwatch.config.ECSTaskDefScrapeConfig;
+import ai.asserts.aws.cloudwatch.config.ScrapeConfig;
+import ai.asserts.aws.cloudwatch.model.CWNamespace;
+import ai.asserts.aws.exporter.ECSServiceDiscoveryExporter.Labels;
+import ai.asserts.aws.exporter.ECSServiceDiscoveryExporter.StaticConfig;
+import ai.asserts.aws.resource.Resource;
+import ai.asserts.aws.resource.ResourceMapper;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableSortedMap;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import software.amazon.awssdk.services.ecs.EcsClient;
+import software.amazon.awssdk.services.ecs.model.ContainerDefinition;
+import software.amazon.awssdk.services.ecs.model.DescribeTaskDefinitionRequest;
+import software.amazon.awssdk.services.ecs.model.KeyValuePair;
+import software.amazon.awssdk.services.ecs.model.PortMapping;
+import software.amazon.awssdk.services.ecs.model.Task;
+import software.amazon.awssdk.services.ecs.model.TaskDefinition;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import static ai.asserts.aws.MetricNameUtil.SCRAPE_ERROR_COUNT_METRIC;
+import static ai.asserts.aws.MetricNameUtil.SCRAPE_LATENCY_METRIC;
+import static ai.asserts.aws.MetricNameUtil.SCRAPE_NAMESPACE_LABEL;
+import static ai.asserts.aws.MetricNameUtil.SCRAPE_OPERATION_LABEL;
+import static ai.asserts.aws.MetricNameUtil.SCRAPE_REGION_LABEL;
+import static java.lang.String.format;
+
+@Component
+@Slf4j
+@AllArgsConstructor
+public class ECSTaskUtil {
+    private final ResourceMapper resourceMapper;
+    private final BasicMetricCollector metricCollector;
+    public static final String ENI = "ElasticNetworkInterface";
+    public static final String PRIVATE_IPv4ADDRESS = "privateIPv4Address";
+
+    public boolean hasAllInfo(Task task) {
+        return "RUNNING".equals(task.lastStatus()) && task.hasAttachments() && task.attachments()
+                .stream()
+                .filter(attachment -> attachment.type().equals(ENI) && attachment.hasDetails())
+                .flatMap(attachment -> attachment.details().stream())
+                .anyMatch(detail -> detail.name().equals(PRIVATE_IPv4ADDRESS));
+    }
+
+    public Optional<StaticConfig> buildScrapeTarget(ScrapeConfig scrapeConfig, EcsClient ecsClient,
+                                                    Resource cluster, Resource service, Task task) {
+        StaticConfig.StaticConfigBuilder staticConfigBuilder = StaticConfig.builder();
+
+        String ipAddress = "unknown";
+        Integer port = -1;
+        Resource taskDefResource = resourceMapper.map(task.taskDefinitionArn())
+                .orElseThrow(() -> new RuntimeException("Unknown resource ARN: " + task.taskDefinitionArn()));
+        Resource taskResource = resourceMapper.map(task.taskArn())
+                .orElseThrow(() -> new RuntimeException("Unknown resource ARN: " + task.taskArn()));
+
+        Labels.LabelsBuilder labelsBuilder = Labels.builder()
+                .cluster(cluster.getName())
+                .job(service.getName())
+                .taskDefName(taskDefResource.getName())
+                .taskDefVersion(taskDefResource.getVersion())
+                .taskId(taskResource.getName())
+                .metricsPath("/metrics");
+
+
+        Optional<ECSTaskDefScrapeConfig> defOpt = scrapeConfig.getECSScrapeConfig(taskDefResource);
+        String containerName = defOpt.map(ECSTaskDefScrapeConfig::getContainerDefinitionName).orElse(null);
+
+        Optional<KeyValuePair> ipAddressOpt = task.attachments().stream()
+                .filter(attachment -> attachment.type().equals(ENI) && attachment.hasDetails())
+                .flatMap(attachment -> attachment.details().stream())
+                .filter(detail -> detail.name().equals(PRIVATE_IPv4ADDRESS))
+                .findFirst();
+        if (ipAddressOpt.isPresent()) {
+            ipAddress = ipAddressOpt.get().value();
+        }
+
+        ImmutableSortedMap<String, String> telemetryLabels = ImmutableSortedMap.of(
+                SCRAPE_NAMESPACE_LABEL, CWNamespace.ecs_svc.getNormalizedNamespace(),
+                SCRAPE_OPERATION_LABEL, "describeTaskDefinition",
+                SCRAPE_REGION_LABEL, cluster.getRegion()
+        );
+        try {
+            long tick = System.currentTimeMillis();
+            TaskDefinition taskDefinition = ecsClient.describeTaskDefinition(DescribeTaskDefinitionRequest.builder()
+                    .taskDefinition(task.taskDefinitionArn())
+                    .build()).taskDefinition();
+            tick = System.currentTimeMillis() - tick;
+            metricCollector.recordLatency(SCRAPE_LATENCY_METRIC, telemetryLabels, tick);
+
+            if (taskDefinition.hasContainerDefinitions()) {
+                List<ContainerDefinition> containerDefinitions = taskDefinition.containerDefinitions();
+                List<PortMapping> portMappings;
+                if (containerDefinitions.size() == 1) {
+                    portMappings = containerDefinitions.get(0).portMappings();
+                } else {
+                    portMappings = containerDefinitions.stream()
+                            .filter(containerDefinition -> containerDefinition.name().equals(containerName))
+                            .map(ContainerDefinition::portMappings)
+                            .findFirst().orElse(Collections.emptyList());
+                }
+
+                Optional<PortMapping> specifiedPort = Optional.empty();
+                if (defOpt.isPresent()) {
+                    ECSTaskDefScrapeConfig taskDefConfig = defOpt.get();
+                    if (taskDefConfig.getContainerPort() != null) {
+                        specifiedPort = portMappings.stream()
+                                .filter(mapping -> mapping.containerPort().equals(taskDefConfig.getContainerPort()))
+                                .findFirst();
+                    }
+                    if (!specifiedPort.isPresent()) {
+                        log.warn("No scrape target port found as per configuration {}", taskDefConfig);
+                    }
+                    labelsBuilder = labelsBuilder.metricsPath(taskDefConfig.getMetricPath());
+                }
+
+                if (specifiedPort.isPresent()) {
+                    port = specifiedPort.get().hostPort();
+                } else if (portMappings.size() == 1) {
+                    log.warn("For task {} in Cluster {}, Service {}, Task Definition {} picking only known port ",
+                            task.taskArn(), cluster.getName(), service.getName(), taskDefResource.getName());
+                    port = portMappings.get(0).hostPort();
+                } else {
+                    log.error("For task {} in Cluster {}, Service {}, Task Definition {} could not pick scrape port ",
+                            task.taskArn(), cluster.getName(), service.getName(), taskDefResource.getName());
+                    return Optional.empty();
+                }
+            }
+        } catch (Exception e) {
+            metricCollector.recordCounterValue(SCRAPE_ERROR_COUNT_METRIC, telemetryLabels, 1);
+            log.error("Failed to describe task definition", e);
+            return Optional.empty();
+        }
+        return Optional.of(staticConfigBuilder
+                .labels(labelsBuilder.build())
+                .targets(ImmutableSet.of(format("%s:%d", ipAddress, port)))
+                .build());
+    }
+}

--- a/src/main/java/ai/asserts/aws/resource/Resource.java
+++ b/src/main/java/ai/asserts/aws/resource/Resource.java
@@ -26,6 +26,7 @@ public class Resource {
     private final ResourceType type;
     private final String name;
     private final String region;
+    private final String version;
     private final Resource childOf;
     @EqualsAndHashCode.Exclude
     private final String arn;

--- a/src/main/java/ai/asserts/aws/resource/ResourceType.java
+++ b/src/main/java/ai/asserts/aws/resource/ResourceType.java
@@ -5,6 +5,7 @@ public enum ResourceType {
     ECSCluster,
     ECSService,
     ECSTaskDef,
+    ECSTask,
     SNSTopic,
     EventBus,
     SQSQueue, // SQS Queue

--- a/src/test/java/ai/asserts/aws/MetricTaskManagerTest.java
+++ b/src/test/java/ai/asserts/aws/MetricTaskManagerTest.java
@@ -7,6 +7,7 @@ import ai.asserts.aws.cloudwatch.config.NamespaceConfig;
 import ai.asserts.aws.cloudwatch.config.ScrapeConfig;
 import ai.asserts.aws.cloudwatch.config.ScrapeConfigProvider;
 import ai.asserts.aws.cloudwatch.model.CWNamespace;
+import ai.asserts.aws.exporter.ECSServiceDiscoveryExporter;
 import ai.asserts.aws.exporter.LambdaLogMetricScrapeTask;
 import ai.asserts.aws.exporter.MetricScrapeTask;
 import com.google.common.collect.ImmutableList;
@@ -36,6 +37,7 @@ public class MetricTaskManagerTest extends EasyMockSupport {
     private MetricScrapeTask metricScrapeTask;
     private LambdaLogMetricScrapeTask logMetricScrapeTask;
     private ScrapeConfig scrapeConfig;
+    private ECSServiceDiscoveryExporter ecsServiceDiscoveryExporter;
     private TaskThreadPool taskThreadPool;
     private ExecutorService executorService;
 
@@ -48,11 +50,13 @@ public class MetricTaskManagerTest extends EasyMockSupport {
         metricScrapeTask = mock(MetricScrapeTask.class);
         collectorRegistry = mock(CollectorRegistry.class);
         logMetricScrapeTask = mock(LambdaLogMetricScrapeTask.class);
+        ecsServiceDiscoveryExporter = mock(ECSServiceDiscoveryExporter.class);
         taskThreadPool = mock(TaskThreadPool.class);
         executorService = mock(ExecutorService.class);
 
         replayAll();
-        testClass = new MetricTaskManager(collectorRegistry, beanFactory, scrapeConfigProvider, taskThreadPool) {
+        testClass = new MetricTaskManager(collectorRegistry, beanFactory, scrapeConfigProvider, ecsServiceDiscoveryExporter,
+                taskThreadPool) {
             @Override
             MetricScrapeTask newScrapeTask(String region, Integer interval, Integer delay) {
                 return metricScrapeTask;
@@ -123,6 +127,8 @@ public class MetricTaskManagerTest extends EasyMockSupport {
 
         expect(executorService.submit(capture(capture1))).andReturn(null);
         expect(executorService.submit(capture(capture2))).andReturn(null);
+
+        expect(executorService.submit(ecsServiceDiscoveryExporter)).andReturn(null);
 
         replayAll();
         testClass.triggerScrapes();

--- a/src/test/java/ai/asserts/aws/cloudwatch/config/ECSTaskDefScrapeConfigTest.java
+++ b/src/test/java/ai/asserts/aws/cloudwatch/config/ECSTaskDefScrapeConfigTest.java
@@ -1,0 +1,34 @@
+/*
+ *  Copyright © 2020.
+ *  Asserts, Inc. - All Rights Reserved
+ */
+package ai.asserts.aws.cloudwatch.config;
+
+import ai.asserts.aws.resource.Resource;
+import org.junit.jupiter.api.Test;
+
+import static ai.asserts.aws.resource.ResourceType.ECSTaskDef;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class ECSTaskDefScrapeConfigTest {
+    @Test
+    public void isApplicable_false() {
+        ECSTaskDefScrapeConfig config = new ECSTaskDefScrapeConfig()
+                .withTaskDefinitionName("task-def");
+        assertFalse(config.isApplicable(Resource.builder()
+                .type(ECSTaskDef)
+                .name("task-def1")
+                .build()));
+    }
+
+    @Test
+    public void isApplicable_true() {
+        ECSTaskDefScrapeConfig config = new ECSTaskDefScrapeConfig()
+                .withTaskDefinitionName("task-def");
+        assertTrue(config.isApplicable(Resource.builder()
+                .type(ECSTaskDef)
+                .name("task-def")
+                .build()));
+    }
+}

--- a/src/test/java/ai/asserts/aws/cloudwatch/config/ScrapeConfigProviderTest.java
+++ b/src/test/java/ai/asserts/aws/cloudwatch/config/ScrapeConfigProviderTest.java
@@ -1,16 +1,25 @@
 
 package ai.asserts.aws.cloudwatch.config;
 
+import ai.asserts.aws.ObjectMapperFactory;
 import ai.asserts.aws.cloudwatch.model.MetricStat;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import org.easymock.EasyMockSupport;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-public class ScrapeConfigProviderTest {
+public class ScrapeConfigProviderTest extends EasyMockSupport {
+    private ScrapeConfigProvider testClass;
+
+    @BeforeEach
+    public void setup() {
+        testClass = new ScrapeConfigProvider(new ObjectMapperFactory(), null);
+    }
 
     @Test
     void validWithDefaults() {
@@ -26,7 +35,6 @@ public class ScrapeConfigProviderTest {
                 .regions(ImmutableSet.of("region1"))
                 .namespaces(ImmutableList.of(namespaceConfig))
                 .build();
-        ScrapeConfigProvider testClass = new ScrapeConfigProvider(null);
         testClass.validateConfig(scrapeConfig);
         assertEquals(60, namespaceConfig.getScrapeInterval());
         assertEquals(60, namespaceConfig.getPeriod());
@@ -50,7 +58,6 @@ public class ScrapeConfigProviderTest {
                 .period(300)
                 .namespaces(ImmutableList.of(namespaceConfig))
                 .build();
-        ScrapeConfigProvider testClass = new ScrapeConfigProvider(null);
         testClass.validateConfig(scrapeConfig);
         assertEquals(600, namespaceConfig.getScrapeInterval());
         assertEquals(300, namespaceConfig.getPeriod());
@@ -77,7 +84,6 @@ public class ScrapeConfigProviderTest {
                 .period(300)
                 .namespaces(ImmutableList.of(namespaceConfig))
                 .build();
-        ScrapeConfigProvider testClass = new ScrapeConfigProvider(null);
         testClass.validateConfig(scrapeConfig);
         assertEquals(600, namespaceConfig.getScrapeInterval());
         assertEquals(300, namespaceConfig.getPeriod());
@@ -105,7 +111,6 @@ public class ScrapeConfigProviderTest {
                 .period(300)
                 .namespaces(ImmutableList.of(namespaceConfig))
                 .build();
-        ScrapeConfigProvider testClass = new ScrapeConfigProvider(null);
         testClass.validateConfig(scrapeConfig);
         assertEquals(600, namespaceConfig.getScrapeInterval());
         assertEquals(300, namespaceConfig.getPeriod());
@@ -115,7 +120,9 @@ public class ScrapeConfigProviderTest {
 
     @Test
     void integrationTest() {
-        ScrapeConfigProvider testClass = new ScrapeConfigProvider("src/test/resources/cloudwatch_scrape_config.yml");
+        ScrapeConfigProvider testClass = new ScrapeConfigProvider(
+                new ObjectMapperFactory(),
+                "src/test/resources/cloudwatch_scrape_config.yml");
         assertNotNull(testClass.getScrapeConfig());
     }
 }

--- a/src/test/java/ai/asserts/aws/cloudwatch/config/ScrapeConfigTest.java
+++ b/src/test/java/ai/asserts/aws/cloudwatch/config/ScrapeConfigTest.java
@@ -1,0 +1,111 @@
+/*
+ *  Copyright © 2020.
+ *  Asserts, Inc. - All Rights Reserved
+ */
+package ai.asserts.aws.cloudwatch.config;
+
+import ai.asserts.aws.resource.Resource;
+import com.google.common.collect.ImmutableList;
+import org.easymock.EasyMockSupport;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.easymock.EasyMock.expect;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class ScrapeConfigTest extends EasyMockSupport {
+    @Test
+    public void getLambdaConfig_NoNamespaces() {
+        ScrapeConfig scrapeConfig = ScrapeConfig.builder()
+                .namespaces(ImmutableList.of())
+                .build();
+
+        replayAll();
+        assertEquals(Optional.empty(), scrapeConfig.getLambdaConfig());
+        verifyAll();
+    }
+
+    @Test
+    public void getLambdaConfig_Exists() {
+        NamespaceConfig mockConfig = mock(NamespaceConfig.class);
+        ScrapeConfig scrapeConfig = ScrapeConfig.builder()
+                .namespaces(ImmutableList.of(mockConfig))
+                .build();
+
+        expect(mockConfig.getName()).andReturn("AWS/Lambda");
+        expect(mockConfig.getName()).andReturn("lambda");
+
+        replayAll();
+        assertEquals(Optional.of(mockConfig), scrapeConfig.getLambdaConfig());
+        assertEquals(Optional.of(mockConfig), scrapeConfig.getLambdaConfig());
+        verifyAll();
+    }
+
+    @Test
+    public void getLambdaConfig_None() {
+        NamespaceConfig mockConfig = mock(NamespaceConfig.class);
+        ScrapeConfig scrapeConfig = ScrapeConfig.builder()
+                .namespaces(ImmutableList.of(mockConfig))
+                .build();
+
+        expect(mockConfig.getName()).andReturn("AWS/ECS");
+
+        replayAll();
+        assertEquals(Optional.empty(), scrapeConfig.getLambdaConfig());
+        verifyAll();
+    }
+
+    @Test
+    public void isECSMonitoringOn_True() {
+        ScrapeConfig scrapeConfig = ScrapeConfig.builder()
+                .namespaces(ImmutableList.of(NamespaceConfig.builder()
+                        .name("AWS/ECS")
+                        .build()))
+                .build();
+        assertTrue(scrapeConfig.isECSMonitoringOn());
+
+        scrapeConfig = ScrapeConfig.builder()
+                .namespaces(ImmutableList.of(NamespaceConfig.builder()
+                        .name("ECS/ContainerInsights")
+                        .build()))
+                .build();
+        assertTrue(scrapeConfig.isECSMonitoringOn());
+    }
+
+    @Test
+    public void isECSMonitoringOn_False() {
+        ScrapeConfig scrapeConfig = ScrapeConfig.builder()
+                .namespaces(ImmutableList.of(NamespaceConfig.builder()
+                        .name("AWS/Lambda")
+                        .build()))
+                .build();
+        assertFalse(scrapeConfig.isECSMonitoringOn());
+
+        scrapeConfig = ScrapeConfig.builder().build();
+        assertFalse(scrapeConfig.isECSMonitoringOn());
+    }
+
+    @Test
+    public void getECSScrapeConfig_None() {
+        ScrapeConfig scrapeConfig = ScrapeConfig.builder().build();
+        assertEquals(Optional.empty(), scrapeConfig.getECSScrapeConfig(Resource.builder().build()));
+    }
+
+    @Test
+    public void getECSScrapeConfig_Exists() {
+        ECSTaskDefScrapeConfig mockConfig = mock(ECSTaskDefScrapeConfig.class);
+        ScrapeConfig scrapeConfig = ScrapeConfig.builder()
+                .ecsTaskScrapeConfigs(ImmutableList.of(mockConfig))
+                .build();
+        Resource resource = mock(Resource.class);
+
+        expect(mockConfig.isApplicable(resource)).andReturn(true);
+
+        replayAll();
+        assertEquals(Optional.of(mockConfig), scrapeConfig.getECSScrapeConfig(resource));
+        verifyAll();
+    }
+}

--- a/src/test/java/ai/asserts/aws/cloudwatch/model/CWNamespaceTest.java
+++ b/src/test/java/ai/asserts/aws/cloudwatch/model/CWNamespaceTest.java
@@ -1,0 +1,19 @@
+/*
+ *  Copyright © 2020.
+ *  Asserts, Inc. - All Rights Reserved
+ */
+package ai.asserts.aws.cloudwatch.model;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class CWNamespaceTest {
+    @Test
+    void isThisNamespace() {
+        assertTrue(CWNamespace.lambda.isThisNamespace("AWS/Lambda"));
+        assertTrue(CWNamespace.lambda.isThisNamespace("lambda"));
+        assertFalse(CWNamespace.lambda.isThisNamespace("AWS/ECS"));
+    }
+}

--- a/src/test/java/ai/asserts/aws/exporter/ECSServiceDiscoveryExporterTest.java
+++ b/src/test/java/ai/asserts/aws/exporter/ECSServiceDiscoveryExporterTest.java
@@ -1,0 +1,364 @@
+/*
+ *  Copyright © 2020.
+ *  Asserts, Inc. - All Rights Reserved
+ */
+package ai.asserts.aws.exporter;
+
+import ai.asserts.aws.AWSClientProvider;
+import ai.asserts.aws.ObjectMapperFactory;
+import ai.asserts.aws.cloudwatch.config.ScrapeConfig;
+import ai.asserts.aws.cloudwatch.config.ScrapeConfigProvider;
+import ai.asserts.aws.exporter.ECSServiceDiscoveryExporter.StaticConfig;
+import ai.asserts.aws.resource.Resource;
+import ai.asserts.aws.resource.ResourceMapper;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectWriter;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
+import org.easymock.EasyMockSupport;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.services.ecs.EcsClient;
+import software.amazon.awssdk.services.ecs.model.DescribeTasksRequest;
+import software.amazon.awssdk.services.ecs.model.DescribeTasksResponse;
+import software.amazon.awssdk.services.ecs.model.ListClustersResponse;
+import software.amazon.awssdk.services.ecs.model.ListServicesRequest;
+import software.amazon.awssdk.services.ecs.model.ListServicesResponse;
+import software.amazon.awssdk.services.ecs.model.ListTasksRequest;
+import software.amazon.awssdk.services.ecs.model.ListTasksResponse;
+import software.amazon.awssdk.services.ecs.model.Task;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import static ai.asserts.aws.MetricNameUtil.SCRAPE_ERROR_COUNT_METRIC;
+import static ai.asserts.aws.MetricNameUtil.SCRAPE_LATENCY_METRIC;
+import static ai.asserts.aws.resource.ResourceType.ECSCluster;
+import static ai.asserts.aws.resource.ResourceType.ECSService;
+import static org.easymock.EasyMock.anyLong;
+import static org.easymock.EasyMock.anyObject;
+import static org.easymock.EasyMock.eq;
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.expectLastCall;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class ECSServiceDiscoveryExporterTest extends EasyMockSupport {
+    private ScrapeConfigProvider scrapeConfigProvider;
+    private ScrapeConfig scrapeConfig;
+    private AWSClientProvider awsClientProvider;
+    private EcsClient ecsClient;
+    private ResourceMapper resourceMapper;
+    private Resource resource;
+    private ECSTaskUtil ecsTaskUtil;
+    private BasicMetricCollector metricCollector;
+    private ObjectMapperFactory objectMapperFactory;
+    private ObjectMapper objectMapper;
+    private ObjectWriter objectWriter;
+    private StaticConfig mockStaticConfig;
+
+    @BeforeEach
+    public void setup() {
+        scrapeConfigProvider = mock(ScrapeConfigProvider.class);
+        scrapeConfig = mock(ScrapeConfig.class);
+        awsClientProvider = mock(AWSClientProvider.class);
+        ecsClient = mock(EcsClient.class);
+        resourceMapper = mock(ResourceMapper.class);
+        resource = mock(Resource.class);
+        ecsTaskUtil = mock(ECSTaskUtil.class);
+        metricCollector = mock(BasicMetricCollector.class);
+        objectMapperFactory = mock(ObjectMapperFactory.class);
+        objectMapper = mock(ObjectMapper.class);
+        objectWriter = mock(ObjectWriter.class);
+        mockStaticConfig = mock(StaticConfig.class);
+    }
+
+    @Test
+    public void run() throws Exception {
+        expect(scrapeConfigProvider.getScrapeConfig()).andReturn(scrapeConfig);
+        expect(scrapeConfig.isECSMonitoringOn()).andReturn(true);
+        expect(scrapeConfig.getRegions()).andReturn(ImmutableSet.of("region1", "region2"));
+
+        expect(awsClientProvider.getECSClient("region1")).andReturn(ecsClient);
+        expect(ecsClient.listClusters()).andReturn(ListClustersResponse.builder()
+                .clusterArns("arn1", "arn2")
+                .build());
+        metricCollector.recordLatency(eq(SCRAPE_LATENCY_METRIC), anyObject(), anyLong());
+        expect(resourceMapper.map("arn1")).andReturn(Optional.of(resource));
+        expect(resourceMapper.map("arn2")).andReturn(Optional.of(resource));
+
+        expect(awsClientProvider.getECSClient("region2")).andReturn(ecsClient);
+        expect(ecsClient.listClusters()).andReturn(ListClustersResponse.builder()
+                .clusterArns("arn3", "arn4")
+                .build());
+        metricCollector.recordLatency(eq(SCRAPE_LATENCY_METRIC), anyObject(), anyLong());
+        expect(resourceMapper.map("arn3")).andReturn(Optional.of(resource));
+        expect(resourceMapper.map("arn4")).andReturn(Optional.of(resource));
+        ecsClient.close();
+        expectLastCall().times(2);
+
+        expect(objectMapperFactory.getObjectMapper()).andReturn(objectMapper);
+        expect(objectMapper.writerWithDefaultPrettyPrinter()).andReturn(objectWriter);
+
+        objectWriter.writeValue(anyObject(File.class), eq(ImmutableList.of(
+                mockStaticConfig, mockStaticConfig, mockStaticConfig, mockStaticConfig
+        )));
+        replayAll();
+        ECSServiceDiscoveryExporter testClass = new ECSServiceDiscoveryExporter(scrapeConfigProvider, awsClientProvider,
+                resourceMapper, ecsTaskUtil, metricCollector, objectMapperFactory) {
+            @Override
+            List<StaticConfig> buildTargetsInCluster(ScrapeConfig sc, EcsClient client, Resource _cluster) {
+                assertEquals(scrapeConfig, sc);
+                assertEquals(ecsClient, client);
+                assertEquals(resource, _cluster);
+                return ImmutableList.of(mockStaticConfig);
+            }
+        };
+        testClass.run();
+
+        verifyAll();
+    }
+
+    @Test
+    public void run_JacksonWriteException() throws Exception {
+        expect(scrapeConfigProvider.getScrapeConfig()).andReturn(scrapeConfig);
+        expect(scrapeConfig.isECSMonitoringOn()).andReturn(true);
+        expect(scrapeConfig.getRegions()).andReturn(ImmutableSet.of("region1", "region2"));
+
+        expect(awsClientProvider.getECSClient("region1")).andReturn(ecsClient);
+        expect(ecsClient.listClusters()).andReturn(ListClustersResponse.builder()
+                .clusterArns("arn1", "arn2")
+                .build());
+        metricCollector.recordLatency(eq(SCRAPE_LATENCY_METRIC), anyObject(), anyLong());
+        expect(resourceMapper.map("arn1")).andReturn(Optional.of(resource));
+        expect(resourceMapper.map("arn2")).andReturn(Optional.of(resource));
+
+        expect(awsClientProvider.getECSClient("region2")).andReturn(ecsClient);
+        expect(ecsClient.listClusters()).andReturn(ListClustersResponse.builder()
+                .clusterArns("arn3", "arn4")
+                .build());
+        metricCollector.recordLatency(eq(SCRAPE_LATENCY_METRIC), anyObject(), anyLong());
+        expect(resourceMapper.map("arn3")).andReturn(Optional.of(resource));
+        expect(resourceMapper.map("arn4")).andReturn(Optional.of(resource));
+        ecsClient.close();
+        expectLastCall().times(2);
+
+        expect(objectMapperFactory.getObjectMapper()).andReturn(objectMapper);
+        expect(objectMapper.writerWithDefaultPrettyPrinter()).andReturn(objectWriter);
+
+        objectWriter.writeValue(anyObject(File.class), eq(ImmutableList.of(
+                mockStaticConfig, mockStaticConfig, mockStaticConfig, mockStaticConfig
+        )));
+        expectLastCall().andThrow(new IOException());
+        metricCollector.recordCounterValue(eq(SCRAPE_ERROR_COUNT_METRIC), anyObject(), eq(1));
+
+        replayAll();
+        ECSServiceDiscoveryExporter testClass = new ECSServiceDiscoveryExporter(scrapeConfigProvider, awsClientProvider,
+                resourceMapper, ecsTaskUtil, metricCollector, objectMapperFactory) {
+            @Override
+            List<StaticConfig> buildTargetsInCluster(ScrapeConfig sc, EcsClient client, Resource _cluster) {
+                assertEquals(scrapeConfig, sc);
+                assertEquals(ecsClient, client);
+                assertEquals(resource, _cluster);
+                return ImmutableList.of(mockStaticConfig);
+            }
+        };
+        testClass.run();
+
+        verifyAll();
+    }
+
+    @Test
+    public void run_AWSException() throws Exception {
+        expect(scrapeConfigProvider.getScrapeConfig()).andReturn(scrapeConfig);
+        expect(scrapeConfig.isECSMonitoringOn()).andReturn(true);
+        expect(scrapeConfig.getRegions()).andReturn(ImmutableSet.of("region1", "region2"));
+
+        expect(awsClientProvider.getECSClient("region1")).andReturn(ecsClient);
+        expect(ecsClient.listClusters()).andThrow(new RuntimeException());
+        metricCollector.recordCounterValue(eq(SCRAPE_ERROR_COUNT_METRIC), anyObject(), eq(1));
+
+        expect(awsClientProvider.getECSClient("region2")).andReturn(ecsClient);
+        expect(ecsClient.listClusters()).andThrow(new RuntimeException());
+        metricCollector.recordCounterValue(eq(SCRAPE_ERROR_COUNT_METRIC), anyObject(), eq(1));
+
+        expect(objectMapperFactory.getObjectMapper()).andReturn(objectMapper);
+        expect(objectMapper.writerWithDefaultPrettyPrinter()).andReturn(objectWriter);
+        objectWriter.writeValue(anyObject(File.class), eq(ImmutableList.of()));
+        ecsClient.close();
+        expectLastCall().times(2);
+
+        replayAll();
+        ECSServiceDiscoveryExporter testClass = new ECSServiceDiscoveryExporter(scrapeConfigProvider, awsClientProvider,
+                resourceMapper, ecsTaskUtil, metricCollector, objectMapperFactory);
+        testClass.run();
+
+        verifyAll();
+    }
+
+    @Test
+    public void buildTargetsInCluster() {
+        Resource cluster = Resource.builder()
+                .region("region1")
+                .arn("arn1")
+                .name("cluster")
+                .type(ECSCluster)
+                .build();
+
+        expect(ecsClient.listServices(ListServicesRequest.builder()
+                .cluster(cluster.getName())
+                .build()))
+                .andReturn(ListServicesResponse.builder()
+                        .serviceArns("arn1", "arn2")
+                        .build());
+        expect(resourceMapper.map("arn1")).andReturn(Optional.of(resource));
+        expect(resourceMapper.map("arn2")).andReturn(Optional.of(resource));
+
+        replayAll();
+        ECSServiceDiscoveryExporter testClass = new ECSServiceDiscoveryExporter(scrapeConfigProvider, awsClientProvider,
+                resourceMapper, ecsTaskUtil, metricCollector, objectMapperFactory) {
+            @Override
+            List<StaticConfig> buildTargetsInService(ScrapeConfig sc, EcsClient client, Resource _cluster,
+                                                     Resource _service) {
+                assertEquals(scrapeConfig, sc);
+                assertEquals(ecsClient, client);
+                assertEquals(cluster, _cluster);
+                return ImmutableList.of(mockStaticConfig);
+            }
+        };
+        assertEquals(
+                ImmutableList.of(mockStaticConfig, mockStaticConfig),
+                testClass.buildTargetsInCluster(scrapeConfig, ecsClient, cluster));
+
+        verifyAll();
+    }
+
+    @Test
+    public void buildTargetsInService() {
+        Resource cluster = Resource.builder()
+                .region("region1")
+                .arn("cluster-arn")
+                .name("cluster")
+                .type(ECSCluster)
+                .build();
+
+        Resource service = Resource.builder()
+                .region("region1")
+                .arn("service-arn")
+                .name("service")
+                .type(ECSService)
+                .childOf(cluster)
+                .build();
+
+        List<String> taskArns = new ArrayList<>();
+        for (int i = 0; i < 101; i++) {
+            taskArns.add("arn" + i);
+        }
+
+        List<Set<String>> expectedARNs = new ArrayList<>();
+        expectedARNs.add(Sets.newHashSet(taskArns.subList(0, 100)));
+        expectedARNs.add(Sets.newHashSet(taskArns.subList(100, 101)));
+
+        expect(ecsClient.listTasks(ListTasksRequest.builder()
+                .cluster(cluster.getName())
+                .serviceName(service.getName())
+                .build()))
+                .andReturn(ListTasksResponse.builder()
+                        .nextToken("token1")
+                        .taskArns(expectedARNs.get(0))
+                        .build());
+        metricCollector.recordLatency(eq(SCRAPE_LATENCY_METRIC), anyObject(), anyLong());
+
+        expect(ecsClient.listTasks(ListTasksRequest.builder()
+                .cluster(cluster.getName())
+                .serviceName(service.getName())
+                .nextToken("token1")
+                .build()))
+                .andReturn(ListTasksResponse.builder()
+                        .taskArns(expectedARNs.get(1))
+                        .build());
+        metricCollector.recordLatency(eq(SCRAPE_LATENCY_METRIC), anyObject(), anyLong());
+
+        List<Set<String>> actualARNs = new ArrayList<>();
+
+        replayAll();
+        ECSServiceDiscoveryExporter testClass = new ECSServiceDiscoveryExporter(scrapeConfigProvider, awsClientProvider,
+                resourceMapper, ecsTaskUtil, metricCollector, objectMapperFactory) {
+            @Override
+            List<StaticConfig> buildTaskTargets(ScrapeConfig sc, EcsClient client, Resource _cluster,
+                                                Resource _service, Set<String> taskIds) {
+                assertEquals(scrapeConfig, sc);
+                assertEquals(ecsClient, client);
+                assertEquals(cluster, _cluster);
+                assertEquals(service, _service);
+                actualARNs.add(taskIds);
+                return ImmutableList.of(mockStaticConfig);
+            }
+        };
+        assertEquals(
+                ImmutableList.of(mockStaticConfig, mockStaticConfig),
+                testClass.buildTargetsInService(scrapeConfig, ecsClient, cluster, service));
+        assertEquals(expectedARNs, actualARNs);
+
+        verifyAll();
+    }
+
+    @Test
+    public void buildTaskTargets() {
+        Resource cluster = Resource.builder()
+                .region("region1")
+                .arn("cluster-arn")
+                .name("cluster")
+                .type(ECSCluster)
+                .build();
+
+        Resource service = Resource.builder()
+                .region("region1")
+                .arn("service-arn")
+                .name("service")
+                .type(ECSService)
+                .childOf(cluster)
+                .build();
+
+        Set<String> taskArns = new LinkedHashSet<>();
+        for (int i = 0; i < 2; i++) {
+            taskArns.add("arn" + i);
+        }
+
+        Task task1 = Task.builder()
+                .taskArn("arn1")
+                .build();
+        Task task2 = Task.builder()
+                .taskArn("arn2")
+                .build();
+        expect(ecsClient.describeTasks(DescribeTasksRequest.builder()
+                .cluster(cluster.getName())
+                .tasks(taskArns)
+                .build())).andReturn(DescribeTasksResponse.builder()
+                .tasks(task1, task2)
+                .build());
+
+        expect(ecsTaskUtil.hasAllInfo(task1)).andReturn(true);
+        expect(ecsTaskUtil.hasAllInfo(task2)).andReturn(true);
+
+        expect(ecsTaskUtil.buildScrapeTarget(scrapeConfig, ecsClient, cluster, service, task1))
+                .andReturn(Optional.of(mockStaticConfig));
+
+        expect(ecsTaskUtil.buildScrapeTarget(scrapeConfig, ecsClient, cluster, service, task2))
+                .andReturn(Optional.of(mockStaticConfig));
+
+        replayAll();
+        ECSServiceDiscoveryExporter testClass = new ECSServiceDiscoveryExporter(scrapeConfigProvider, awsClientProvider,
+                resourceMapper, ecsTaskUtil, metricCollector, objectMapperFactory);
+        assertEquals(
+                ImmutableList.of(mockStaticConfig, mockStaticConfig),
+                testClass.buildTaskTargets(scrapeConfig, ecsClient, cluster, service, taskArns));
+
+        verifyAll();
+    }
+}

--- a/src/test/java/ai/asserts/aws/exporter/ECSTaskUtilTest.java
+++ b/src/test/java/ai/asserts/aws/exporter/ECSTaskUtilTest.java
@@ -1,0 +1,289 @@
+/*
+ *  Copyright © 2020.
+ *  Asserts, Inc. - All Rights Reserved
+ */
+package ai.asserts.aws.exporter;
+
+import ai.asserts.aws.cloudwatch.config.ECSTaskDefScrapeConfig;
+import ai.asserts.aws.cloudwatch.config.ScrapeConfig;
+import ai.asserts.aws.exporter.ECSServiceDiscoveryExporter.StaticConfig;
+import ai.asserts.aws.resource.Resource;
+import ai.asserts.aws.resource.ResourceMapper;
+import com.google.common.collect.ImmutableSet;
+import org.easymock.EasyMockSupport;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.services.ecs.EcsClient;
+import software.amazon.awssdk.services.ecs.model.Attachment;
+import software.amazon.awssdk.services.ecs.model.ContainerDefinition;
+import software.amazon.awssdk.services.ecs.model.DescribeTaskDefinitionRequest;
+import software.amazon.awssdk.services.ecs.model.DescribeTaskDefinitionResponse;
+import software.amazon.awssdk.services.ecs.model.KeyValuePair;
+import software.amazon.awssdk.services.ecs.model.PortMapping;
+import software.amazon.awssdk.services.ecs.model.Task;
+import software.amazon.awssdk.services.ecs.model.TaskDefinition;
+
+import java.util.Optional;
+
+import static ai.asserts.aws.MetricNameUtil.SCRAPE_ERROR_COUNT_METRIC;
+import static ai.asserts.aws.MetricNameUtil.SCRAPE_LATENCY_METRIC;
+import static ai.asserts.aws.exporter.ECSTaskUtil.ENI;
+import static ai.asserts.aws.exporter.ECSTaskUtil.PRIVATE_IPv4ADDRESS;
+import static org.easymock.EasyMock.anyLong;
+import static org.easymock.EasyMock.anyObject;
+import static org.easymock.EasyMock.eq;
+import static org.easymock.EasyMock.expect;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class ECSTaskUtilTest extends EasyMockSupport {
+    private ResourceMapper resourceMapper;
+    private BasicMetricCollector metricCollector;
+    private EcsClient ecsClient;
+    private ScrapeConfig scrapeConfig;
+    private ECSTaskDefScrapeConfig taskDefScrapeConfig;
+    private ECSTaskUtil testClass;
+    private Resource cluster;
+    private Resource service;
+    private Resource task;
+    private Resource taskDef;
+
+    @BeforeEach
+    public void setup() {
+        resourceMapper = mock(ResourceMapper.class);
+        metricCollector = mock(BasicMetricCollector.class);
+        ecsClient = mock(EcsClient.class);
+        scrapeConfig = mock(ScrapeConfig.class);
+        taskDefScrapeConfig = mock(ECSTaskDefScrapeConfig.class);
+        testClass = new ECSTaskUtil(resourceMapper, metricCollector);
+
+        cluster = Resource.builder()
+                .name("cluster")
+                .region("us-west-2")
+                .build();
+        service = Resource.builder()
+                .name("service")
+                .region("us-west-2")
+                .build();
+        task = Resource.builder()
+                .name("task-id")
+                .region("us-west-2")
+                .build();
+        taskDef = Resource.builder()
+                .name("task-def")
+                .version("5")
+                .region("us-west-2")
+                .build();
+    }
+
+    @Test
+    public void hasAllInfo_false() {
+        replayAll();
+        assertFalse(testClass.hasAllInfo(Task.builder().build()));
+        verifyAll();
+    }
+
+    @Test
+    public void hasAllInfo_true() {
+        replayAll();
+        assertTrue(testClass.hasAllInfo(Task.builder()
+                .lastStatus("RUNNING")
+                .attachments(Attachment.builder()
+                        .type(ENI)
+                        .details(KeyValuePair.builder()
+                                .name(PRIVATE_IPv4ADDRESS)
+                                .value("10.20.30.40")
+                                .build())
+                        .build())
+                .build()));
+        verifyAll();
+    }
+
+    @Test
+    public void buildScrapeTarget_use_taskdef_config_success() {
+        expect(resourceMapper.map("task-def-arn")).andReturn(Optional.of(taskDef));
+        expect(resourceMapper.map("task-arn")).andReturn(Optional.of(task));
+
+        expect(scrapeConfig.getECSScrapeConfig(taskDef)).andReturn(Optional.of(taskDefScrapeConfig));
+        expect(taskDefScrapeConfig.getContainerDefinitionName()).andReturn("model-builder");
+        expect(taskDefScrapeConfig.getMetricPath()).andReturn("/metric/path");
+        expect(taskDefScrapeConfig.getContainerPort()).andReturn(8080).anyTimes();
+
+        expect(ecsClient.describeTaskDefinition(DescribeTaskDefinitionRequest.builder()
+                .taskDefinition("task-def-arn")
+                .build())).andReturn(DescribeTaskDefinitionResponse.builder()
+                .taskDefinition(TaskDefinition.builder()
+                        .containerDefinitions(ContainerDefinition.builder()
+                                        .name("model-builder")
+                                        .portMappings(PortMapping.builder()
+                                                .containerPort(8080)
+                                                .hostPort(53234)
+                                                .build())
+                                        .build(),
+                                ContainerDefinition.builder()
+                                        .name("sidecar")
+                                        .portMappings(PortMapping.builder()
+                                                .containerPort(8081)
+                                                .hostPort(53235)
+                                                .build())
+                                        .build())
+                        .build())
+                .build());
+        metricCollector.recordLatency(eq(SCRAPE_LATENCY_METRIC), anyObject(), anyLong());
+
+        replayAll();
+        Optional<StaticConfig> staticConfigOpt = testClass.buildScrapeTarget(scrapeConfig, ecsClient, cluster,
+                service, Task.builder()
+                        .taskArn("task-arn")
+                        .taskDefinitionArn("task-def-arn")
+                        .lastStatus("RUNNING")
+                        .attachments(Attachment.builder()
+                                .type(ENI)
+                                .details(KeyValuePair.builder()
+                                        .name(PRIVATE_IPv4ADDRESS)
+                                        .value("10.20.30.40")
+                                        .build())
+                                .build())
+                        .build());
+        assertTrue(staticConfigOpt.isPresent());
+        StaticConfig staticConfig = staticConfigOpt.get();
+        assertAll(
+                () -> assertEquals("cluster", staticConfig.getLabels().getCluster()),
+                () -> assertEquals("service", staticConfig.getLabels().getJob()),
+                () -> assertEquals("task-def", staticConfig.getLabels().getTaskDefName()),
+                () -> assertEquals("5", staticConfig.getLabels().getTaskDefVersion()),
+                () -> assertEquals("task-id", staticConfig.getLabels().getTaskId()),
+                () -> assertEquals("/metric/path", staticConfig.getLabels().getMetricsPath()),
+                () -> assertEquals(ImmutableSet.of("10.20.30.40:53234"), staticConfig.getTargets())
+        );
+        verifyAll();
+    }
+
+    @Test
+    public void buildScrapeTarget_without_taskdef_config_success() {
+        expect(resourceMapper.map("task-def-arn")).andReturn(Optional.of(taskDef));
+        expect(resourceMapper.map("task-arn")).andReturn(Optional.of(task));
+
+        expect(scrapeConfig.getECSScrapeConfig(taskDef)).andReturn(Optional.empty());
+        expect(ecsClient.describeTaskDefinition(DescribeTaskDefinitionRequest.builder()
+                .taskDefinition("task-def-arn")
+                .build())).andReturn(DescribeTaskDefinitionResponse.builder()
+                .taskDefinition(TaskDefinition.builder()
+                        .containerDefinitions(ContainerDefinition.builder()
+                                .name("model-builder")
+                                .portMappings(PortMapping.builder()
+                                        .containerPort(8080)
+                                        .hostPort(53234)
+                                        .build())
+                                .build())
+                        .build())
+                .build());
+        metricCollector.recordLatency(eq(SCRAPE_LATENCY_METRIC), anyObject(), anyLong());
+
+        replayAll();
+        Optional<StaticConfig> staticConfigOpt = testClass.buildScrapeTarget(scrapeConfig, ecsClient, cluster,
+                service, Task.builder()
+                        .taskArn("task-arn")
+                        .taskDefinitionArn("task-def-arn")
+                        .lastStatus("RUNNING")
+                        .attachments(Attachment.builder()
+                                .type(ENI)
+                                .details(KeyValuePair.builder()
+                                        .name(PRIVATE_IPv4ADDRESS)
+                                        .value("10.20.30.40")
+                                        .build())
+                                .build())
+                        .build());
+        assertTrue(staticConfigOpt.isPresent());
+        StaticConfig staticConfig = staticConfigOpt.get();
+        assertAll(
+                () -> assertEquals("cluster", staticConfig.getLabels().getCluster()),
+                () -> assertEquals("service", staticConfig.getLabels().getJob()),
+                () -> assertEquals("task-id", staticConfig.getLabels().getTaskId()),
+                () -> assertEquals("5", staticConfig.getLabels().getTaskDefVersion()),
+                () -> assertEquals("/metrics", staticConfig.getLabels().getMetricsPath()),
+                () -> assertEquals(ImmutableSet.of("10.20.30.40:53234"), staticConfig.getTargets())
+        );
+        verifyAll();
+    }
+
+    @Test
+    public void buildScrapeTarget_without_taskdef_config_no_result() {
+        expect(resourceMapper.map("task-def-arn")).andReturn(Optional.of(taskDef));
+        expect(resourceMapper.map("task-arn")).andReturn(Optional.of(task));
+
+        expect(scrapeConfig.getECSScrapeConfig(taskDef)).andReturn(Optional.empty());
+        expect(ecsClient.describeTaskDefinition(DescribeTaskDefinitionRequest.builder()
+                .taskDefinition("task-def-arn")
+                .build())).andReturn(DescribeTaskDefinitionResponse.builder()
+                .taskDefinition(TaskDefinition.builder()
+                        .containerDefinitions(ContainerDefinition.builder()
+                                        .name("model-builder")
+                                        .portMappings(PortMapping.builder()
+                                                .containerPort(8080)
+                                                .hostPort(53234)
+                                                .build())
+                                        .build(),
+                                ContainerDefinition.builder()
+                                        .name("sidecar")
+                                        .portMappings(PortMapping.builder()
+                                                .containerPort(8081)
+                                                .hostPort(53235)
+                                                .build())
+                                        .build())
+                        .build())
+                .build());
+        metricCollector.recordLatency(eq(SCRAPE_LATENCY_METRIC), anyObject(), anyLong());
+
+        replayAll();
+        Optional<StaticConfig> staticConfigOpt = testClass.buildScrapeTarget(scrapeConfig, ecsClient, cluster,
+                service, Task.builder()
+                        .taskArn("task-arn")
+                        .taskDefinitionArn("task-def-arn")
+                        .lastStatus("RUNNING")
+                        .attachments(Attachment.builder()
+                                .type(ENI)
+                                .details(KeyValuePair.builder()
+                                        .name(PRIVATE_IPv4ADDRESS)
+                                        .value("10.20.30.40")
+                                        .build())
+                                .build())
+                        .build());
+        assertFalse(staticConfigOpt.isPresent());
+        verifyAll();
+    }
+
+    @Test
+    public void buildScrapeTarget_use_taskdef_config_exception() {
+        expect(resourceMapper.map("task-def-arn")).andReturn(Optional.of(taskDef));
+        expect(resourceMapper.map("task-arn")).andReturn(Optional.of(task));
+
+        expect(scrapeConfig.getECSScrapeConfig(taskDef)).andReturn(Optional.of(taskDefScrapeConfig));
+        expect(taskDefScrapeConfig.getContainerDefinitionName()).andReturn("model-builder");
+        expect(taskDefScrapeConfig.getContainerPort()).andReturn(8080).anyTimes();
+
+        expect(ecsClient.describeTaskDefinition(DescribeTaskDefinitionRequest.builder()
+                .taskDefinition("task-def-arn")
+                .build())).andThrow(new RuntimeException());
+        metricCollector.recordCounterValue(eq(SCRAPE_ERROR_COUNT_METRIC), anyObject(), eq(1));
+
+        replayAll();
+        Optional<StaticConfig> staticConfigOpt = testClass.buildScrapeTarget(scrapeConfig, ecsClient, cluster,
+                service, Task.builder()
+                        .taskArn("task-arn")
+                        .taskDefinitionArn("task-def-arn")
+                        .lastStatus("RUNNING")
+                        .attachments(Attachment.builder()
+                                .type(ENI)
+                                .details(KeyValuePair.builder()
+                                        .name(PRIVATE_IPv4ADDRESS)
+                                        .value("10.20.30.40")
+                                        .build())
+                                .build())
+                        .build());
+        assertFalse(staticConfigOpt.isPresent());
+        verifyAll();
+    }
+}

--- a/src/test/java/ai/asserts/aws/resource/ResourceMapperTest.java
+++ b/src/test/java/ai/asserts/aws/resource/ResourceMapperTest.java
@@ -9,6 +9,7 @@ import java.util.Optional;
 import static ai.asserts.aws.resource.ResourceType.DynamoDBTable;
 import static ai.asserts.aws.resource.ResourceType.ECSCluster;
 import static ai.asserts.aws.resource.ResourceType.ECSService;
+import static ai.asserts.aws.resource.ResourceType.ECSTask;
 import static ai.asserts.aws.resource.ResourceType.ECSTaskDef;
 import static ai.asserts.aws.resource.ResourceType.EventBus;
 import static ai.asserts.aws.resource.ResourceType.LambdaFunction;
@@ -153,12 +154,26 @@ public class ResourceMapperTest {
 
     @Test
     public void map_ECS_TaskDefinition() {
-        String arn = "arn:aws:ecs:us-west-2:342994379019:task-definition/task-definition:1";
+        String arn = "arn:aws:ecs:us-west-2:342994379019:task-definition/item-service-v2:5";
         assertEquals(
                 Optional.of(Resource.builder()
                         .type(ECSTaskDef).arn(arn)
                         .region("us-west-2")
-                        .name("task-definition")
+                        .name("item-service-v2")
+                        .version("5")
+                        .build()),
+                testClass.map(arn)
+        );
+    }
+
+    @Test
+    public void map_ECS_Task() {
+        String arn = "arn:aws:ecs:us-west-2:342994379019:task/ecs-sample-app/34c11488dc56429fb67e2996b5ceaa74";
+        assertEquals(
+                Optional.of(Resource.builder()
+                        .type(ECSTask).arn(arn)
+                        .region("us-west-2")
+                        .name("34c11488dc56429fb67e2996b5ceaa74")
                         .build()),
                 testClass.map(arn)
         );


### PR DESCRIPTION
[ch9929]

If ECS Monitoring is enabled, exporter will generated service discovery file of the form. The IP will be the private IP of the task instances. Currently only `ElasticNetworkInterface` based port binding is supported. This allows the container port and host ports to be the same. In the absence of ENI, things should still work but it is not tested.

`aws ecs describe-tasks --cluster ecs-sample-app --tasks 34c11488dc56429fb67e2996b5ceaa74`

will yield something like 

```
{
    "tasks": [
        {
            "attachments": [
                {
                    "id": "06e29dab-045b-4e98-92b7-f266732644c7",
                    "type": "ElasticNetworkInterface",
                    "status": "ATTACHED",
                    "details": [
                        {
                            "name": "subnetId",
                            "value": "subnet-06dd8126a27e2bd75"
                        },
                        {
                            "name": "networkInterfaceId",
                            "value": "eni-0c8a82ea8d6302dc8"
                        },
                        {
                            "name": "macAddress",
                            "value": "02:49:51:db:b7:81"
                        },
                        {
                            "name": "privateDnsName",
                            "value": "ip-10-8-12-252.us-west-2.compute.internal"
                        },
                        {
                            "name": "privateIPv4Address",
                            "value": "10.8.12.252"
                        }
                    ]
                }
            ],
            "attributes": [
                {
                    "name": "ecs.cpu-architecture",
                    "value": "x86_64"
                }
            ],
            "availabilityZone": "us-west-2b",
            "clusterArn": "arn:aws:ecs:us-west-2:342994379019:cluster/ecs-sample-app",
            "connectivity": "CONNECTED",
            "connectivityAt": 1637559607.294,
            "containers": [
                {
                    "containerArn": "arn:aws:ecs:us-west-2:342994379019:container/ecs-sample-app/34c11488dc56429fb67e2996b5ceaa74/47edbdf3-9b09-4716-bb05-5b8506788c14",
                    "taskArn": "arn:aws:ecs:us-west-2:342994379019:task/ecs-sample-app/34c11488dc56429fb67e2996b5ceaa74",
                    "name": "item-service-v2",
                    "image": "342994379019.dkr.ecr.us-west-2.amazonaws.com/auction-item-service:latest",
                    "imageDigest": "sha256:591a7ad49da97ab51e584657da400a7f2add1089af3fda2ca732912f376741e8",
                    "runtimeId": "34c11488dc56429fb67e2996b5ceaa74-468474003",
                    "lastStatus": "RUNNING",
                    "networkBindings": [],
                    "networkInterfaces": [
                        {
                            "attachmentId": "06e29dab-045b-4e98-92b7-f266732644c7",
                            "privateIpv4Address": "10.8.12.252"
                        }
                    ],
                    "healthStatus": "UNKNOWN",
                    "cpu": "0"
                }
            ],
            "cpu": "512",
            "createdAt": 1637559603.454,
            "desiredStatus": "RUNNING",
            "group": "service:item-service",
            "healthStatus": "UNKNOWN",
            "lastStatus": "RUNNING",
            "launchType": "FARGATE",
            "memory": "1024",
            "overrides": {
                "containerOverrides": [
                    {
                        "name": "item-service-v2"
                    }
                ],
                "inferenceAcceleratorOverrides": []
            },
            "platformVersion": "1.4.0",
            "pullStartedAt": 1637559621.51,
            "pullStoppedAt": 1637559627.0,
            "startedAt": 1637559628.2,
            "startedBy": "ecs-svc/8453336267805434132",
            "tags": [],
            "taskArn": "arn:aws:ecs:us-west-2:342994379019:task/ecs-sample-app/34c11488dc56429fb67e2996b5ceaa74",
            "taskDefinitionArn": "arn:aws:ecs:us-west-2:342994379019:task-definition/item-service-v2:5",
            "version": 3
        }
    ],
    "failures": []
}
```

```
- targets:
  - 10.8.12.252:8080
  labels:
    job: item-service
    __metrics_path__: /actuator/prometheus
    ecs_cluster: ecs-sample-app
    ecs_taskdef_name: item-service-v2
    ecs_taskdef_version: 5
    ecs_task_id: 34c11488dc56429fb67e2996b5ceaa74
- targets:
  - 10.8.2.61:8080
  labels:
    job: item-service
    __metrics_path__: /actuator/prometheus
    ecs_cluster: ecs-sample-app
    ecs_taskdef_name: item-service-v2
    ecs_taskdef_version: 5
    ecs_task_id: 73ba63fa11a4488487c3098cb75c5c7d
```

